### PR TITLE
Expose the connection object

### DIFF
--- a/src/main/java/org/imintel/mbtiles4j/MBTilesReader.java
+++ b/src/main/java/org/imintel/mbtiles4j/MBTilesReader.java
@@ -91,4 +91,13 @@ public class MBTilesReader {
 			throw new MBTilesReadException("Could not get min zoom", e);
 		}
     }
+    
+    /**
+     * Expose the Connection object
+     * 
+     * @return the current Connection object
+     */
+    public Connection getConnection() {
+        return connection;
+    }
 }

--- a/src/main/java/org/imintel/mbtiles4j/MBTilesWriter.java
+++ b/src/main/java/org/imintel/mbtiles4j/MBTilesWriter.java
@@ -126,4 +126,13 @@ public class MBTilesWriter {
         return file;
     }
 
+    /**
+     * Expose the Connection object
+     * This is for example useful for turning off auto commit.
+     * 
+     * @return the current Connection object
+     */
+    public Connection getConnection() {
+        return connection;
+    }
 }


### PR DESCRIPTION
The default for SQLite is to auto commit, this can be very expensive. Exposing the connection allows us to set auto commit false before extensive operations and then commit once finished.